### PR TITLE
Fix Mac Support

### DIFF
--- a/CurrentPlatform.cs
+++ b/CurrentPlatform.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace FalconUDP
+{
+    internal enum OS
+    {
+        Windows,
+        Linux,
+        MacOSX,
+        Unknown
+    }
+
+    internal static class CurrentPlatform
+    {
+        private static bool init = false;
+        private static OS os;
+
+        [DllImport ("libc")]
+        static extern int uname (IntPtr buf);
+
+        private static void Init()
+        {
+            if (!init)
+            {
+                PlatformID pid = Environment.OSVersion.Platform;
+
+                switch (pid) 
+                {
+                    case PlatformID.Win32NT:
+                    case PlatformID.Win32S:
+                    case PlatformID.Win32Windows:
+                    case PlatformID.WinCE:
+                        os = OS.Windows;
+                        break;
+                    case PlatformID.MacOSX:
+                        os = OS.MacOSX;
+                        break;
+                    case PlatformID.Unix:
+
+                        // Mac can return a value of Unix sometimes, We need to double check it.
+                        IntPtr buf = IntPtr.Zero;
+                        try
+                        {
+                            buf = Marshal.AllocHGlobal (8192);
+
+                            if (uname (buf) == 0) {
+                                string sos = Marshal.PtrToStringAnsi (buf);
+                                if (sos == "Darwin")
+                                {
+                                    os = OS.MacOSX;
+                                    return;
+                                }
+                            }
+                        } catch {
+                        } finally {
+                            if (buf != IntPtr.Zero)
+                                Marshal.FreeHGlobal (buf);
+                        }
+
+                        os = OS.Linux;
+                        break;
+                    default:
+                        os = OS.Unknown;
+                        break;
+                }
+
+                init = true;
+            }
+        }
+
+        public static OS OS
+        {
+            get
+            {
+                Init();
+                return os;
+            }
+        }
+    }
+}
+

--- a/FalconPeer.cs
+++ b/FalconPeer.cs
@@ -1285,10 +1285,11 @@ namespace FalconUDP
 
                             uint mask = FalconHelper.GetNetMaskFromNumOfBits(24); // class C
 #pragma warning disable 0618
-#if !LINUX
-                            if (addrInfo.IPv4Mask != null)
-                                mask = (uint)addrInfo.IPv4Mask.Address;
-#endif
+                            if (CurrentPlatform.OS != OS.Linux) 
+                            {
+                                if (addrInfo.IPv4Mask != null)
+                                    mask = (uint)addrInfo.IPv4Mask.Address;
+                            }
                             uint ip = (uint)addrInfo.Address.Address;
                             uint broadcast = ip | ~mask;
                             broadcastEndPoints.Add(new IPEndPoint(new IPAddress((long)broadcast), Port));

--- a/FalconUDP.csproj
+++ b/FalconUDP.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Statistics.cs" />
     <Compile Include="GenericObjectPool.cs" />
     <Compile Include="TransceiverFactory.cs" />
+    <Compile Include="CurrentPlatform.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Protocol.txt" />
@@ -132,4 +133,14 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentSwitchBody="True" IndentBlocksInsideExpressions="True" AnonymousMethodBraceStyle="NextLine" PropertyBraceStyle="NextLine" PropertyGetBraceStyle="NextLine" PropertySetBraceStyle="NextLine" EventBraceStyle="NextLine" EventAddBraceStyle="NextLine" EventRemoveBraceStyle="NextLine" StatementBraceStyle="NextLine" ElseNewLinePlacement="NewLine" CatchNewLinePlacement="NewLine" FinallyNewLinePlacement="NewLine" WhileNewLinePlacement="DoNotCare" ArrayInitializerWrapping="DoNotChange" ArrayInitializerBraceStyle="NextLine" BeforeMethodDeclarationParentheses="False" BeforeMethodCallParentheses="False" BeforeConstructorDeclarationParentheses="False" NewLineBeforeConstructorInitializerColon="NewLine" NewLineAfterConstructorInitializerColon="SameLine" BeforeDelegateDeclarationParentheses="False" NewParentheses="False" SpacesBeforeBrackets="False" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
 </Project>

--- a/SocketTransceiver.cs
+++ b/SocketTransceiver.cs
@@ -40,9 +40,10 @@ namespace FalconUDP
 #if !MONO
                     socket.SetIPProtectionLevel(IPProtectionLevel.EdgeRestricted);
 #endif
-#if !LINUX
-                    socket.IOControl(-1744830452, new byte[] { 0 }, new byte[] { 0 }); // http://stackoverflow.com/questions/10332630/connection-reset-on-receiving-packet-in-udp-server
-#endif
+                    if (CurrentPlatform.OS != OS.Linux) 
+                    {
+                        socket.IOControl(-1744830452, new byte[] { 0 }, new byte[] { 0 }); // http://stackoverflow.com/questions/10332630/connection-reset-on-receiving-packet-in-udp-server
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
Mac needs some of the things that Linux doesnt.
However rather than building a completely seperate binary
we just check the platform and call the appropriate methods.
There is still the issue of

```
socket.SetIPProtectionLevel
```

which is NOT available on Mono. Looks like that is the only
reason we need a seperate binary for Windows.

Also added code formatting policy so Xamarin Studio doesn't keep using tabs
